### PR TITLE
Add posibility to bind results

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ module.exports = function(environment) {
       type: 'PUT',
       ajaxOptions: {},
       pushToStore: false,
-      normalizeOperation: ''
+      normalizeOperation: '',
+      promiseType: null
     },
   };
 
@@ -132,6 +133,27 @@ It's great for API with request data format restrictions
   - dasherize
   - decamelize
   - underscore
+
+
+#### `promiseType`
+You can easily observe a returned model by changing promiseType to `array` or `object` according to what type of data
+your server will return.
+
+When `array`:
+```js
+model.customAction({}, { promiseType: 'array' }) // returns DS.PromiseArray
+```
+
+When `object`:
+```js
+model.customAction({}, { promiseType: 'object' }) // returns DS.PromiseObject
+```
+
+When `null` (default):
+```js
+model.customAction({}, { promiseType: null }) // returns Promise
+```
+`null` is useful if you don't care about the response or just want to use `then` on the promise without using `binding` or display it in the template.
 
 # Development
 

--- a/addon/config.js
+++ b/addon/config.js
@@ -2,5 +2,6 @@ export default {
   type: 'PUT',
   ajaxOptions: {},
   pushToStore: false,
-  normalizeOperation: ''
+  normalizeOperation: '',
+  promiseType: null
 };

--- a/tests/dummy/app/components/model-action/component.js
+++ b/tests/dummy/app/components/model-action/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+const { Component, inject, computed } = Ember;
+
+export default Component.extend({
+  store: inject.service(),
+
+  post: computed('property', function() {
+    return this.get('store').createRecord('post', { id: 1 });
+  }),
+
+  status: computed('post', function() {
+    return this.get('post').publish();
+  })
+});

--- a/tests/dummy/app/components/model-action/template.hbs
+++ b/tests/dummy/app/components/model-action/template.hbs
@@ -1,0 +1,1 @@
+{{status.published}}

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,8 +1,12 @@
 import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
 import { modelAction, resourceAction } from 'ember-custom-actions';
 
 export default Model.extend({
-  publish: modelAction('publish'),
+  name: attr(),
+  published: attr(),
+
+  publish: modelAction('publish', { promiseType: 'object' }),
   list: resourceAction('list'),
   search: resourceAction('search', { type: 'GET', normalizeOperation: 'dasherize' })
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import Pretender from 'pretender';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  init() {
+    this._super(...arguments);
+    this.server = new Pretender();
+    this.mockServer();
+  },
+
+  mockServer() {
+    this.server.put('/posts/:id/publish', (request) => {
+      return [200, {}, `{"data": {"id": ${request.params.id}, "type": "Post", "attributes": {"published": true}}}`];
+    });
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,1 @@
-{{!-- The following component displays Ember's default welcome message. --}}
-{{welcome-page}}
-{{!-- Feel free to remove this! --}}
-
-{{outlet}}
+{{model-action}}

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -1,3 +1,7 @@
+/* eslint ember-suave/no-direct-property-access:1 */
+
+import Ember from 'ember';
+import DS from 'ember-data';
 import { moduleForModel, test } from 'ember-qunit';
 import Pretender from 'pretender';
 
@@ -125,8 +129,28 @@ test('resource action pushes to store', function(assert) {
   assert.equal(store.peekAll('post').get('length'), 1);
 
   model.list(payload).then((response) => {
-    assert.equal(response.get('length'), 2);
+    assert.equal(response.length, 2);
     assert.equal(store.peekAll('post').get('length'), 3);
     done();
   });
+});
+
+test('promiseTypes', function(assert) {
+  assert.expect(6);
+
+  this.server.put('/posts/list', (request) => {
+    assert.equal(request.url, '/posts/list');
+
+    return [200, {}, '{"data": [{"id": "2", "type": "post"},{"id": "3", "type": "post"}]}'];
+  });
+
+  let model = this.subject();
+
+  let promise = model.list();
+  let promiseArray = model.list(null, { promiseType: 'array' });
+  let promiseObject = model.list(null, { promiseType: 'object' });
+
+  assert.equal(promise.constructor, Ember.RSVP.Promise);
+  assert.equal(promiseArray.constructor, DS.PromiseArray);
+  assert.equal(promiseObject.constructor, DS.PromiseObject);
 });


### PR DESCRIPTION
#### `promiseType`
You can easily observe a returned model by changing promiseType to `array` or `object` according to what type of data
your server will return.

When `array`:
```js
model.customAction({}, { promiseType: 'array' }) // returns DS.PromiseArray
```

When `object`:
```js
model.customAction({}, { promiseType: 'object' }) // returns DS.PromiseObject
```

When `null` (default):
```js
model.customAction({}, { promiseType: null }) // returns Promise
```
`null` is useful if you don't care about the response or just want to use `then` on the promise without using `binding` or display it in the template.