### PR TITLE
Add REST serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,26 @@ Base of the URL which is generated for the action. If not defined, `urlType` is 
 Your own ajax options (e.g. headers)
 
 #### `pushToStore`
-If you want to push the received data to the store, set this option to `true` and change your application `JSONAPISerializer` to:
+If you want to push the received data to the store, set this option to `true` and change your application serializer:
+
+- If you are using `JSONAPISerializer`:
+
 ``` js
 // app/serializers/application.js
 
 import { JSONAPISerializer } from 'ember-custom-actions';
 export default JSONAPISerializer.extend();
 ```
+
+- If you are using `RESTSerializer`:
+
+``` js
+// app/serializers/application.js
+
+import { RESTSerializer } from 'ember-custom-actions';
+export default RESTSerializer.extend();
+```
+
 #### `normalizeOperation`
 You can define how your outgoing data should be serialized
 

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -6,7 +6,16 @@ import UrlBuilder from '../utils/url-builder';
 import normalizePayload from '../utils/normalize-payload';
 import defaultConfig from '../config';
 
-const { assign, getOwner, computed, Object, ObjectProxy, ArrayProxy, PromiseProxyMixin } = Ember;
+const {
+  assign,
+  getOwner,
+  computed,
+  Object,
+  ObjectProxy,
+  ArrayProxy,
+  PromiseProxyMixin,
+  typeOf
+} = Ember;
 
 const promiseTypes = {
   array: ArrayProxy.extend(PromiseProxyMixin),
@@ -80,7 +89,7 @@ export default Object.extend({
 
   _promise() {
     return this.get('adapter').ajax(this.get('url'), this.get('requestType'), this.get('data')).then((response) => {
-      if (this.get('config.pushToStore') && response.data) {
+      if (this.get('config.pushToStore') && typeOf(response) === 'object') {
         return this.get('serializer').pushPayload(this.get('store'), response);
       } else {
         return response;

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -10,11 +10,11 @@ const {
   assign,
   getOwner,
   computed,
-  Object,
+  Object: emberObject,
   ObjectProxy,
   ArrayProxy,
   PromiseProxyMixin,
-  typeOf
+  typeOf: emberTypeOf
 } = Ember;
 
 const promiseTypes = {
@@ -22,7 +22,7 @@ const promiseTypes = {
   object: ObjectProxy.extend(PromiseProxyMixin)
 };
 
-export default Object.extend({
+export default emberObject.extend({
   model: null,
   options: {},
   payload: {},
@@ -45,15 +45,15 @@ export default Object.extend({
 
   appConfig: computed('model', function() {
     let config = getOwner(this.get('model')).resolveRegistration('config:environment').emberCustomActions || {};
-    return Object.create(config);
+    return emberObject.create(config);
   }),
 
   defaultConfig: computed(function() {
-    return Object.create(defaultConfig);
+    return emberObject.create(defaultConfig);
   }),
 
   config: computed('defaultConfig', 'options', 'appConfig', function() {
-    return Object.create(assign(this.get('defaultConfig'), this.get('appConfig'), this.get('options')));
+    return emberObject.create(assign(this.get('defaultConfig'), this.get('appConfig'), this.get('options')));
   }),
 
   requestType: computed('config.type', function() {
@@ -73,7 +73,7 @@ export default Object.extend({
   }),
 
   data: computed('config.{normalizeOperation,ajaxOptions}', 'payload', function() {
-    let payload = (this.get('payload') instanceof window.Object) ? this.get('payload') : {};
+    let payload = emberTypeOf(this.get('payload')) === 'object' ? this.get('payload') : {};
     let data = normalizePayload(payload, this.get('config.normalizeOperation'));
     return assign(this.get('config.ajaxOptions'), { data });
   }),
@@ -89,11 +89,15 @@ export default Object.extend({
 
   _promise() {
     return this.get('adapter').ajax(this.get('url'), this.get('requestType'), this.get('data')).then((response) => {
-      if (this.get('config.pushToStore') && typeOf(response) === 'object') {
+      if (this.get('config.pushToStore') && this._validResponse(response)) {
         return this.get('serializer').pushPayload(this.get('store'), response);
       } else {
         return response;
       }
     });
+  },
+
+  _validResponse(object) {
+    return emberTypeOf(object) === 'object' && Object.keys(object).length > 0;
   }
 });

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,6 @@
 import resourceAction from './actions/resource';
 import modelAction from './actions/model';
 import JSONAPISerializer from 'ember-custom-actions/serializers/json-api';
+import RESTSerializer from 'ember-custom-actions/serializers/rest';
 
-export { modelAction, resourceAction, JSONAPISerializer };
+export { modelAction, resourceAction, JSONAPISerializer, RESTSerializer };

--- a/addon/serializers/json-api.js
+++ b/addon/serializers/json-api.js
@@ -1,3 +1,6 @@
+// Please Remove this serializer when feature flag 'ds-pushpayload-return' will be enabled by default
+// https://github.com/emberjs/data/pull/4110
+
 import DS from 'ember-data';
 
 const { JSONAPISerializer } = DS;

--- a/addon/serializers/rest.js
+++ b/addon/serializers/rest.js
@@ -1,0 +1,40 @@
+// Please Remove this serializer when feature flag 'ds-pushpayload-return' will be enabled by default
+// https://github.com/emberjs/data/pull/4110
+
+import Ember from 'ember';
+import DS from 'ember-data';
+import { warn } from 'ember-data/-private/debug';
+
+const { RESTSerializer } = DS;
+const { makeArray } = Ember;
+
+export default RESTSerializer.extend({
+  pushPayload(store, payload) {
+    let documentHash = {
+      data: [],
+      included: []
+    };
+
+    for (let prop in payload) {
+      let modelName = this.modelNameFromPayloadKey(prop);
+      if (!store.modelFactoryFor(modelName)) {
+        warn(this.warnMessageNoModelForKey(prop, modelName), false, {
+          id: 'ds.serializer.model-for-key-missing'
+        });
+        continue;
+      }
+      let type = store.modelFor(modelName);
+      let typeSerializer = store.serializerFor(type.modelName);
+
+      makeArray(payload[prop]).forEach((hash) => {
+        let { data, included } = typeSerializer.normalize(type, hash, prop);
+        documentHash.data.push(data);
+        if (included) {
+          documentHash.included.push(...included);
+        }
+      });
+    }
+
+    return store.push(documentHash);
+  }
+});

--- a/tests/dummy/app/components/page-sections/examples/burn-action/component.js
+++ b/tests/dummy/app/components/page-sections/examples/burn-action/component.js
@@ -12,7 +12,7 @@ export default Component.extend({
     this._super(...arguments);
 
     this.get('server').server.get('/bridges/burn', () => {
-      return [200, { }, '{}'];
+      return [200, { }, 'true'];
     });
   },
 

--- a/tests/dummy/app/models/bike.js
+++ b/tests/dummy/app/models/bike.js
@@ -1,0 +1,8 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+import { modelAction } from 'ember-custom-actions';
+
+export default Model.extend({
+  name: attr(),
+  ride: modelAction('ride', { type: 'PUT' })
+});

--- a/tests/dummy/app/serializers/bike.js
+++ b/tests/dummy/app/serializers/bike.js
@@ -1,0 +1,3 @@
+import { RESTSerializer } from 'ember-custom-actions';
+
+export default RESTSerializer.extend();

--- a/tests/unit/models/bike-test.js
+++ b/tests/unit/models/bike-test.js
@@ -1,0 +1,63 @@
+import { moduleForModel, test } from 'ember-qunit';
+import Pretender from 'pretender';
+
+moduleForModel('bike', 'Unit | Model | bike', {
+  needs: ['config:environment', 'serializer:bike'],
+
+  beforeEach() {
+    this.server = new Pretender();
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('model action', function(assert) {
+  assert.expect(3);
+
+  this.server.put('/bikes/:id/ride', (request) => {
+    let data = JSON.parse(request.requestBody);
+    assert.deepEqual(data, { myParam: 'My first param' });
+    assert.equal(request.url, '/bikes/1/ride');
+
+    return [200, { }, 'true'];
+  });
+
+  let done = assert.async();
+  let payload = { myParam: 'My first param' };
+
+  let model = this.subject();
+  model.set('id', 1);
+
+  model.ride(payload).then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('model action pushes to store', function(assert) {
+  assert.expect(5);
+
+  this.server.put('/bikes/:id/ride', (request) => {
+    let data = JSON.parse(request.requestBody);
+    assert.deepEqual(data, { myParam: 'My first param' });
+    assert.equal(request.url, '/bikes/1/ride');
+
+    return [200, {}, '{ "bikes": { "id": 2 } }'];
+  });
+
+  let done = assert.async();
+  let payload = { myParam: 'My first param' };
+  let store = this.store();
+  let model = this.subject();
+
+  model.set('id', 1);
+  assert.equal(store.peekAll('bike').get('length'), 1);
+
+  model.ride(payload).then((response) => {
+    assert.equal(response[0].get('id'), 2);
+    assert.equal(store.peekAll('bike').get('length'), 2);
+    done();
+  });
+});


### PR DESCRIPTION
This PR will add a custom `RESTSerializer` which should be used in case of `pushToPayload` option.

Big thanks to: @dcyriller