### PR TITLE
Ember custom actions - urlFor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Before you will start with documentation check our demo app: [Ember-Custom-Actio
 
 ### Model actions
 To define custom action like: `posts/1/publish` you can use
-`modelAction(path, options)` method with arguments:
-- `actionId/path` -  if you want to override methods like `urlForCustomAction` use it as `actionId` otherwise, use it as url of the action (in our case it's `publish`)
+`modelAction(actionId/path, options)` method with arguments:
+- `actionId/path` -  if you want to override methods like `urlForCustomAction` (more details in [Adapter customization](#Adapter-customization)) use it as `actionId` otherwise, use it as url of the action (in our case it's `publish`)
 - `options` - optional parameter which will overwrite the configuration options
 
 ```js
@@ -50,8 +50,8 @@ postToPublish.publish(payload, /*{ custom options }*/).then((status) => {
 
 ### Resource actions
 To a define custom action like: `posts/favorites` you can use
-`resourceAction(path, options)` method with arguments:
-- `path` - the url of the action (in our case it's `favorites`)
+`resourceAction(actionId/path, options)` method with arguments:
+- `actionId/path` - if you want to override methods like `urlForCustomAction` (more details in [Adapter customization](#Adapter-customization)) use it as `actionId` otherwise, use it as url of the action (in our case it's `favorites`)
 - `options` - optional parameter which will overwrite the configuration options
 
 ```js
@@ -190,7 +190,9 @@ import { AdapterMixin } from 'ember-custom-actions';
 export default JSONAPIAdapter.extend(AdapterMixin);
 ```
 
-Then you can customize following methods:
+Then you can customize following methods (for both - modelAction and resourceAction):
+* [urlForCustomAction](#urlForCustomAction)
+
 
 #### urlForCustomAction
 ```js
@@ -201,12 +203,12 @@ export default JSONAPIAdapter.extend(AdapterMixin, {
     }
     
     return this._super(...arguments);
-    let url = this._buildURL(modelName, id);
-
-    return urlBuilder(url, requestType, query);
   }
 });
 ```
+requestType - `actionId/path` defined during constructing [modelAction](#Model-actions) or [resourceAction](#Resource-actions)
+returnValue - full URL to action
+
 
 You can also use a shorthand for the default api server:
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ export default JSONAPIAdapter.extend(AdapterMixin, {
 });
 ```
 
+# Migrations
+
+## Migration from v1.6.0
+If you used `buildUrl` in you adapter to customize URL, then you can use from now on [urlForCustomAction](#urlForCustomAction).
+
+
 # Development
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Before you will start with documentation check our demo app: [Ember-Custom-Actio
 
 ### Model actions
 To define custom action like: `posts/1/publish` you can use
-`modelAction(actionId/path, options)` method with arguments:
-- `actionId/path` -  if you want to override methods like `urlForCustomAction` (more details in [Adapter customization](#Adapter-customization)) use it as `actionId` otherwise, use it as url of the action (in our case it's `publish`)
+`modelAction(actionId, options)` method with arguments:
+- `actionId` -  if you want to integrate it with adapter/serializer use it as `actionId` (more details in [Adapter customization](#Adapter-customization)) otherwise, use it as url of the action (in our case it's `publish`)
 - `options` - optional parameter which will overwrite the configuration options
 
 ```js
@@ -51,7 +51,7 @@ postToPublish.publish(payload, /*{ custom options }*/).then((status) => {
 ### Resource actions
 To a define custom action like: `posts/favorites` you can use
 `resourceAction(actionId/path, options)` method with arguments:
-- `actionId/path` - if you want to override methods like `urlForCustomAction` (more details in [Adapter customization](#Adapter-customization)) use it as `actionId` otherwise, use it as url of the action (in our case it's `favorites`)
+- `actionId/path` - if you want to integrate it with adapter/serializer use it as `actionId` (more details in [Adapter customization](#Adapter-customization)) otherwise, use it as url of the action (in our case it's `favorites`)
 - `options` - optional parameter which will overwrite the configuration options
 
 ```js
@@ -207,7 +207,7 @@ export default JSONAPIAdapter.extend(AdapterMixin, {
 });
 ```
 requestType - `actionId/path` defined during constructing [modelAction](#Model-actions) or [resourceAction](#Resource-actions)
-returnValue - full URL to action
+The function returns a full URL of the action
 
 
 You can also use a shorthand for the default api server:
@@ -223,11 +223,6 @@ export default JSONAPIAdapter.extend(AdapterMixin, {
   }
 });
 ```
-
-# Migrations
-
-## Migration from v1.6.0
-If you used `buildUrl` in you adapter to customize URL, then you can use from now on [urlForCustomAction](#urlForCustomAction).
 
 
 # Development

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Before you will start with documentation check our demo app: [Ember-Custom-Actio
 
 ### Model actions
 To define custom action like: `posts/1/publish` you can use
-`modelAction(actionId, options)` method with arguments:
-- `actionId` -  if you want to integrate it with adapter/serializer use it as `actionId` (more details in [Adapter customization](#Adapter-customization)) otherwise, use it as url of the action (in our case it's `publish`)
+`modelAction(actionId/path, options)` method with arguments:
+- `actionId/path` -  if you want to integrate it with adapter/serializer use it as `actionId` (more details in [Adapter customization](#Adapter-customization)) otherwise, use it as url of the action (in our case it's `publish`)
 - `options` - optional parameter which will overwrite the configuration options
 
 ```js

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -115,8 +115,7 @@ export default EmberObject.extend({
   requestUrl() {
     let modelName = this.get('modelName');
     let id = this.get('instance') ? this.get('model.id') : null;
-    let snapshot = this.get('model')._createSnapshot();
-    snapshot.adapterOptions = deepMerge(snapshot.adapterOptions, this.get('config.adapterOptions'));
+    let snapshot = this.get('model')._internalModel.createSnapshot({ adapterOptions: this.get('config.adapterOptions') });
     let actionId = this.get('path');
     let queryParams = this.queryParams();
 

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -111,7 +111,8 @@ export default EmberObject.extend({
   requestUrl() {
     let modelName = this.get('modelName');
     let id = this.get('instance') ? this.get('model.id') : null;
-    let snapshot = this.get('model')._createSnapshot(this.get('config.adapterOptions'));
+    let snapshot = this.get('model')._createSnapshot();
+    snapshot.adapterOptions = deepMerge(snapshot.adapterOptions, this.get('config.adapterOptions'));
     let requestType = this.get('path');
     let query = this.queryParams();
 

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -32,6 +32,10 @@ export default EmberObject.extend({
   init() {
     this._super(...arguments);
     assert('Model has to be persisted!', !(this.get('instance') && !this.get('model.id')));
+
+    let payload = this.get('payload') || {};
+    assert('payload should be an object',  emberTypeOf(payload) === 'object');
+    this.set('payload', payload);
   },
 
   /**
@@ -130,8 +134,7 @@ export default EmberObject.extend({
    * @return {Object}
    */
   requestData() {
-    let payload = emberTypeOf(this.get('payload')) === 'object' ? this.get('payload') : {};
-    let data = normalizePayload(payload, this.get('config.normalizeOperation'));
+    let data = normalizePayload(this.get('payload'), this.get('config.normalizeOperation'));
 
     return deepMerge({}, this.get('config.ajaxOptions'), { data });
   },

--- a/addon/actions/action.js
+++ b/addon/actions/action.js
@@ -26,17 +26,22 @@ export default EmberObject.extend({
   path: '',
   model: null,
   options: {},
-  payload: {},
   instance: false,
 
   init() {
     this._super(...arguments);
     assert('Model has to be persisted!', !(this.get('instance') && !this.get('model.id')));
-
-    let payload = this.get('payload') || {};
-    assert('payload should be an object',  emberTypeOf(payload) === 'object');
-    this.set('payload', payload);
   },
+
+  payload: computed({
+    set(key, value) {
+      if (value === null || value === undefined) {
+        return {};
+      }
+      assert('payload should be an object',  emberTypeOf(value) === 'object');
+      return value;
+    }
+  }),
 
   /**
     @return {DS.Store}

--- a/tests/dummy/app/adapters/car.js
+++ b/tests/dummy/app/adapters/car.js
@@ -1,0 +1,23 @@
+import JSONAPIAdapter from 'ember-data/adapters/json-api';
+import { AdapterMixin } from 'ember-custom-actions';
+
+export default JSONAPIAdapter.extend(AdapterMixin, {
+  urlForCustomAction(modelName, id, snapshot, requestType) {
+    let { adapterOptions: { suffix } } = snapshot;
+    suffix = suffix || '';
+
+    if (requestType === 'clean') {
+      let baseUrl = this._buildURL(modelName, id);
+      return `${baseUrl}/custom-clean`;
+    } else if (requestType === 'fix') {
+      return `/custom-cars/${id}/custom-fix${suffix}`;
+    } else if (requestType === 'clean-all') {
+      let baseUrl = this._buildURL(modelName, id);
+      return `${baseUrl}/custom-clean-all`;
+    } else if (requestType === 'fix-all') {
+      return `/custom-cars/custom-fix-all${suffix}`;
+    }
+
+    return this._super(...arguments);
+  }
+});

--- a/tests/dummy/app/adapters/car.js
+++ b/tests/dummy/app/adapters/car.js
@@ -7,12 +7,12 @@ export default JSONAPIAdapter.extend(AdapterMixin, {
     suffix = suffix || '';
 
     if (requestType === 'clean') {
-      let baseUrl = this._buildURL(modelName, id);
+      let baseUrl = this.buildURL(modelName, id, snapshot, requestType);
       return `${baseUrl}/custom-clean`;
     } else if (requestType === 'fix') {
       return `/custom-cars/${id}/custom-fix${suffix}`;
     } else if (requestType === 'clean-all') {
-      let baseUrl = this._buildURL(modelName, id);
+      let baseUrl = this.buildURL(modelName, id, snapshot, requestType);
       return `${baseUrl}/custom-clean-all`;
     } else if (requestType === 'fix-all') {
       return `/custom-cars/custom-fix-all${suffix}`;

--- a/tests/dummy/app/models/car.js
+++ b/tests/dummy/app/models/car.js
@@ -1,0 +1,12 @@
+import Model from 'ember-data/model';
+import { modelAction, resourceAction } from 'ember-custom-actions';
+
+export default Model.extend({
+  drive: modelAction('drive'),
+  clean: modelAction('clean'),
+  fix: modelAction('fix'),
+
+  moveAll: resourceAction('move-all'),
+  cleanAll: resourceAction('clean-all'),
+  fixAll: resourceAction('fix-all')
+});

--- a/tests/unit/models/car-test.js
+++ b/tests/unit/models/car-test.js
@@ -1,0 +1,165 @@
+// tests for integration with adapter - custom url
+import { moduleForModel, test } from 'ember-qunit';
+import Pretender from 'pretender';
+
+moduleForModel('car', 'Unit | Model | car', {
+  needs: ['config:environment', 'adapter:car'],
+
+  beforeEach() {
+    this.server = new Pretender();
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('creates default url for model action', function(assert) {
+  assert.expect(3);
+
+  this.server.post('/cars/:id/drive', (request) => {
+    assert.deepEqual(request.queryParams, { include: 'owner' });
+    assert.equal(request.url, '/cars/1/drive?include=owner');
+
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+  model.set('id', 1);
+
+  model.drive({}, { queryParams: { include: 'owner' } }).then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url with base url for model action', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/cars/:id/custom-clean', () => {
+    assert.ok(true);
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+  model.set('id', 1);
+
+  model.clean().then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url for model action', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/custom-cars/:id/custom-fix', () => {
+    assert.ok(true);
+
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+  model.set('id', 1);
+
+  model.fix().then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url for model action and passes adapterOptions', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/custom-cars/:id/custom-fix/with-hammer', () => {
+    assert.ok(true);
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+  model.set('id', 1);
+
+  let adapterOptions = { suffix: '/with-hammer' };
+
+  model.fix({}, { adapterOptions }).then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates default url for resource action', function(assert) {
+  assert.expect(3);
+
+  this.server.post('/cars/move-all', (request) => {
+    assert.deepEqual(request.queryParams, { include: 'owner' });
+    assert.equal(request.url, '/cars/move-all?include=owner');
+
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+
+  model.moveAll({}, { queryParams: { include: 'owner' } }).then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url with base url for resource action', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/cars/custom-clean-all', () => {
+    assert.ok(true);
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+
+  model.cleanAll().then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url for resource action', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/custom-cars/custom-fix-all', () => {
+    assert.ok(true);
+
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+
+  model.fixAll().then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});
+
+test('creates custom url for resource action and passes adapterOptions', function(assert) {
+  assert.expect(2);
+
+  this.server.post('/custom-cars/custom-fix-all/with-hammer', () => {
+    assert.ok(true);
+
+    return [200, {}, 'true'];
+  });
+
+  let done = assert.async();
+  let model = this.subject();
+  let adapterOptions = { suffix: '/with-hammer' };
+
+  model.fixAll({}, { adapterOptions }).then((response) => {
+    assert.ok(response, true);
+    done();
+  });
+});

--- a/tests/unit/models/car-test.js
+++ b/tests/unit/models/car-test.js
@@ -1,4 +1,4 @@
-// tests for integration with adapter - custom url
+// tests for integration with adapter - url customization
 import { moduleForModel, test } from 'ember-qunit';
 import Pretender from 'pretender';
 


### PR DESCRIPTION
TODO listed in #27 

If you have any suggestions @Exelord, let me know ;)

I've added some comments (edit: I added them again because I've cancelled review by accident ...).
Passing adpaterOptions didn't work for me so I've changed it a little.


Additional info which could be used for release notes (or migration guide):

### 1. New config API
### Added
- `adapterOptions` can be specified in config (or during calling an action) which will be passed to the adapter. It is empty object by default. It can be used to customize adapter behavior. 

### 4. Adapter support
- `urlForCustomAction` - (...). You can call internally this._buildURL(modelName, id) to get base url for model.

### 5. Action interface
- `payload` - it's not required (it can be undefined or null). It has to be an object if it is passed (not an array, not a string etc.)

### 6. Internal changes
- `buildUrl` is not used anymore internally. If you used `buildUrl` in you adapter to customize URL, then you can use `urlForCustomAction` from now on
- `config` / `defaultConfig` - `defaultConfig` is now defined in `appConfig.emberCustomActions` (`environment.js`)
- `urlType` - removed. URL depends on passed `actionId` (`path`). Not anymore depending on `config.urlType` OR `requestType` (`requestType` renamed to `method`). `actionId` has to be explicitly passed