### PR TITLE
Substitute jQuery.param function

### DIFF
--- a/addon/utils/param.js
+++ b/addon/utils/param.js
@@ -1,0 +1,41 @@
+/* eslint-disable */
+// https://github.com/knowledgecode/jquery-param/blob/master/jquery-param.js
+export default function param(a) {
+  var s = [];
+  var add = function (k, v) {
+    v = typeof v === 'function' ? v() : v;
+    v = v === null ? '' : v === undefined ? '' : v;
+    s[s.length] = encodeURIComponent(k) + '=' + encodeURIComponent(v);
+  };
+  var buildParams = function (prefix, obj) {
+    var i, len, key;
+
+    if (prefix) {
+      if (Array.isArray(obj)) {
+        for (i = 0, len = obj.length; i < len; i++) {
+          buildParams(
+            prefix + '[' + (typeof obj[i] === 'object' && obj[i] ? i : '') + ']',
+            obj[i]
+            );
+        }
+      } else if (String(obj) === '[object Object]') {
+        for (key in obj) {
+          buildParams(prefix + '[' + key + ']', obj[key]);
+        }
+      } else {
+        add(prefix, obj);
+      }
+    } else if (Array.isArray(obj)) {
+      for (i = 0, len = obj.length; i < len; i++) {
+        add(obj[i].name, obj[i].value);
+      }
+    } else {
+      for (key in obj) {
+        buildParams(key, obj[key]);
+      }
+    }
+    return s;
+  };
+
+  return buildParams('', a).join('&');
+}

--- a/addon/utils/url-builder.js
+++ b/addon/utils/url-builder.js
@@ -1,7 +1,7 @@
-import Ember$ from 'jquery';
+import param from './param';
 
 export default function(url, path, queryParams) {
-  let query = Ember$.param(queryParams);
+  let query = param(queryParams);
   let pathUrl = url.charAt(url.length - 1) === '/' ? `${url}${path}` : `${url}/${path}`;
 
   return query ? `${pathUrl}?${query}` : pathUrl;


### PR DESCRIPTION
This removes the only jQuery dependency from the addon.

The reason why the function is bundled is the current relatively poor NPM module story in Ember addons. Hopefully this could be solved soon by `import`ing from [`jquery-param`](http://npmjs.com/package/jquery-param) directly.